### PR TITLE
Cache range sensitivity to reduce I2C traffic in getGaussField()

### DIFF
--- a/Adafruit_QMC5883P.h
+++ b/Adafruit_QMC5883P.h
@@ -142,7 +142,7 @@ class Adafruit_QMC5883P {
 
  private:
   Adafruit_I2CDevice* i2c_dev; ///< Pointer to I2C bus interface
-  float _lsb_per_gauss; ///< Cached sensitivity for Gauss conversion
+  float _lsb_per_gauss;      ///< Cached sensitivity for Gauss conversion
   void _updateSensitivity(qmc5883p_range_t range);
 };
 

--- a/Adafruit_QMC5883P.h
+++ b/Adafruit_QMC5883P.h
@@ -142,7 +142,7 @@ class Adafruit_QMC5883P {
 
  private:
   Adafruit_I2CDevice* i2c_dev; ///< Pointer to I2C bus interface
-  float _lsb_per_gauss;      ///< Cached sensitivity for Gauss conversion
+  float _lsb_per_gauss;       ///< Cached sensitivity for Gauss conversion
   void _updateSensitivity(qmc5883p_range_t range);
 };
 

--- a/Adafruit_QMC5883P.h
+++ b/Adafruit_QMC5883P.h
@@ -142,6 +142,8 @@ class Adafruit_QMC5883P {
 
  private:
   Adafruit_I2CDevice* i2c_dev; ///< Pointer to I2C bus interface
+  float _lsb_per_gauss; ///< Cached sensitivity for Gauss conversion
+  void _updateSensitivity(qmc5883p_range_t range);
 };
 
 #endif


### PR DESCRIPTION
## Summary

`getGaussField()` currently performs **two I2C transactions** per call:
1. `getRawMagnetic()` — reads 6 bytes of sensor data
2. `getRange()` — reads the control register just to compute the LSB-per-Gauss conversion factor

Since the range setting rarely changes during normal operation, the second read is redundant. At 200 Hz ODR, this means ~200 unnecessary I2C reads per second on the bus.

This PR caches the sensitivity value (`_lsb_per_gauss`) as a private class member and updates it only when necessary:

- **`setRange()`** — updates the cache after writing the new range to hardware
- **`begin()`** — syncs the cache with the current hardware range on initialization
- **`softReset()`** — resets the cache to the chip's default (±30G) after a soft reset

This eliminates one I2C transaction from every `getGaussField()` call, effectively halving the I2C bus traffic on the hot path.

### Changes
- Added `float _lsb_per_gauss` private member to `Adafruit_QMC5883P` class
- Added `void _updateSensitivity(qmc5883p_range_t range)` private helper
- Simplified `getGaussField()` to use the cached value directly
- Updated `setRange()`, `begin()`, and `softReset()` to keep the cache in sync

### Impact
- **No API changes** — fully backward compatible
- **No behavioral changes** — same conversion results
- Reduced I2C bus utilization in the data acquisition hot path
- Slightly reduced stack usage per `getGaussField()` call (removed local `float` + `switch`)

## Test plan
- [ ] Verify `getGaussField()` returns correct values across all four range settings (±2G, ±8G, ±12G, ±30G)
- [ ] Verify sensitivity stays in sync after `setRange()` changes
- [ ] Verify `softReset()` correctly resets cached sensitivity to ±30G default
- [ ] Verify `begin()` correctly reads and caches the hardware's current range
- [ ] Run existing `test_QMC5883P` example sketch (cycles through all ranges)
- [ ] Confirm CI build passes (clang-format + platform builds)